### PR TITLE
DOC: Use scientific-python-nightly-wheels for nightly build index

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,12 @@ To test those nightly build, you can use the following command to install from
 the nightly package.
 
 ```sh
-python -m pip install matplotlib --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple  --upgrade --pre
+python -m pip install \
+  --upgrade \
+  --pre \
+  --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \
+  --extra-index-url https://pypi.org/simple \
+  matplotlib
 ```
 
 Note that second `-i` parameter will take priority, it needs to come second if
@@ -50,6 +55,6 @@ name: test
 dependencies:
   - pip
   - pip:
-    - --pre --extra-index https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+    - --pre --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --extra-index-url https://pypi.org/simple
     - matplotlib
 ```

--- a/README.md
+++ b/README.md
@@ -37,8 +37,10 @@ python -m pip install \
   matplotlib
 ```
 
-Note that second `-i` parameter will take priority, it needs to come second if
-you want to pull from nightly otherwise it will pull from PyPI.
+Note that `--index-url` takes priority over `--extra-index-url`.
+Packages, and dependencies, with versions available on the
+[nightly package index][] will be installed from there before falling back to
+the [Python Package Index][PyPI] to install all remaining requested packages.
 
 ```
 if package in nightly:
@@ -58,3 +60,6 @@ dependencies:
     - --pre --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --extra-index-url https://pypi.org/simple
     - matplotlib
 ```
+
+[nightly package index]: https://anaconda.org/scientific-python-nightly-wheels
+[PyPI]: https://pypi.org/


### PR DESCRIPTION
Resolves #9 

Use of `--index-url` for the nightly package index and `--extra-index-url` for [public PyPI](https://pypi.org/) makes the behavior of installation precedence more explicit.

c.f. https://github.com/matplotlib/matplotlib/pull/22752 for discussion of relevance.

Also provide a very short summary of how `--index-url` takes priority over `--extra-index-url` to ensure that if a target package exists on the nightly package index it will be used over a version that exists on public PyPI.

(I'm tagging everyone who is already listed as a contributor to this repo so far for review)