### PR TITLE
MNT: Use '--skip-existing' over '--force'

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,5 +38,8 @@ env
 # upload wheels
 echo "Uploading wheels to anaconda.org..."
 
-anaconda -t $ANACONDA_TOKEN upload --force -u "$ANACONDA_ORG" "$INPUT_ARTIFACTS_PATH"/*.whl
-echo "Index: https://pypi.anaconda.org/$ANACONDA_ORG/simple"
+anaconda --token "${ANACONDA_TOKEN}" upload \
+  --user "${ANACONDA_ORG}" \
+  --skip-existing \
+  "${INPUT_ARTIFACTS_PATH}"/*.whl
+echo "Index: https://pypi.anaconda.org/${ANACONDA_ORG}/simple"


### PR DESCRIPTION
Use `anaconda-client` `upload` command's `--skip-existing` flag over the `--force` flag to avoid redundant uploads, saving time, and to avoid uploading when legitimate errors exist. From `anaconda upload --help`:
```
...
--force: Force a package upload regardless of errors
--skip-existing: Skip errors on package batch upload if it already exists
...
```