### PR TITLE
CI: Add removal of old uploads

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "github-actions"

--- a/.github/workflows/remove-wheels.yml
+++ b/.github/workflows/remove-wheels.yml
@@ -1,0 +1,81 @@
+name: Remove old wheels
+
+on:
+  # Run daily at 1:23 UTC
+  schedule:
+  - cron:  '23 1 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Needed for micromamba pickup
+defaults:
+  run:
+    shell: bash -l {0}
+
+env:
+  N_LATEST_UPLOADS: 5
+  ANACONDA_USER: "scientific-python-nightly-wheels"
+
+jobs:
+  remove:
+
+    runs-on: ubuntu-latest
+    # Set required workflow secrets in the environment for additional security
+    # https://github.com/scientific-python/upload-nightly-action/settings/environments
+    environment:
+      name: remove-old-wheels
+
+    steps:
+      - name: Install micromamba and anaconda-client
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          environment-name: remove-wheels
+          create-args: >-
+            python=3.11
+            anaconda-client=1.11.2
+
+      - name: Show environment
+        run: env
+
+      - name: Show CLI API info
+        run: |
+          anaconda show --help
+          echo ""
+          anaconda remove --help
+
+      - name: Query package index for packages
+        run: |
+          anaconda show "${ANACONDA_USER}" &> >(grep "${ANACONDA_USER}/") | \
+              awk '{print $1}' | \
+              sed 's|.*/||g' > package-names.txt
+
+      - name: Remove old uploads to save space
+        run: |
+          # Remove all _but_ the last ${N_LATEST_UPLOADS} package versions
+          # N.B.: `anaconda show` places the newest packages at the bottom of the output
+          # of the 'Versions' section and package versions are preceded with a '   + '.
+
+          if [ -s package-names.txt ]; then
+              # Remember can't quote subshell as need to split on (space seperated) token
+              for package_name in $(cat package-names.txt); do
+
+                  echo -e "\n# package: ${package_name}"
+
+                  anaconda show "${ANACONDA_USER}/${package_name}" &> >(grep '+') | \
+                      awk '{print $2}' | \
+                      head --lines "-${N_LATEST_UPLOADS}" > remove-package-versions.txt
+
+                  if [ -s remove-package-versions.txt ]; then
+                      for package_version in $(cat remove-package-versions.txt); do
+                          echo "# Removing ${ANACONDA_USER}/${package_name}/${package_version}"
+                          anaconda --token ${{ secrets.ANACONDA_TOKEN }} remove \
+                            --force \
+                            "${ANACONDA_USER}/${package_name}/${package_version}"
+                      done
+                  fi
+
+              done
+          fi


### PR DESCRIPTION
Resolves #4

Remove all but the last `N_LATEST_UPLOADS` (defaulted to `5`) package version uploads to the package index to ensure space. To do this, reply on the output form of `anaconda show` to be able to filter on the item delimiter character sequence for each version currently uploaded.

As an explicit example:

```console
$ anaconda show scientific-python-nightly-wheels/xarray
Using Anaconda API: https://api.anaconda.org
Name:    xarray
Summary: 
Access:  public
Package Types:  Standard Python
Versions:
   + 2023.5.1.dev2+gd8ec3a3f
   + 2023.5.1.dev5+gf96aca45
   + 2023.5.1.dev6+g69445c62
   + 2023.5.1.dev9+g609a9016
   + 2023.5.1.dev10+gf45eb733
   + 2023.5.1.dev11+gfcb81756
   + 2023.5.1.dev12+gb319d867
   + 2023.5.1.dev14+ge3db6164

To install this package with pypi run:
     pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple xarray
```

shows that by filtering on `+`

```console
$ anaconda show scientific-python-nightly-wheels/xarray &> >(grep '+')
   + 2023.5.1.dev2+gd8ec3a3f
   + 2023.5.1.dev5+gf96aca45
   + 2023.5.1.dev6+g69445c62
   + 2023.5.1.dev9+g609a9016
   + 2023.5.1.dev10+gf45eb733
   + 2023.5.1.dev11+gfcb81756
   + 2023.5.1.dev12+gb319d867
   + 2023.5.1.dev14+ge3db6164
```

and then stripping `' + '`

```console
$ anaconda show scientific-python-nightly-wheels/xarray &> >(grep '+') | \
    awk '{print $2}'
2023.5.1.dev2+gd8ec3a3f
2023.5.1.dev5+gf96aca45
2023.5.1.dev6+g69445c62
2023.5.1.dev9+g609a9016
2023.5.1.dev10+gf45eb733
2023.5.1.dev11+gfcb81756
2023.5.1.dev12+gb319d867
2023.5.1.dev14+ge3db6164
```

one can obtain a newline separated list of all package uploads, where the _most recent_ uploads are listed last. After stripping off the `N_LATEST_UPLOADS` lines that correspond to the package versions to keep for testing

```console
$ anaconda show scientific-python-nightly-wheels/xarray &> >(grep '+') | \
    awk '{print $2}' | \
    head --lines -5 > remove-package-versions.txt
$ cat remove-package-versions.txt 
2023.5.1.dev2+gd8ec3a3f
2023.5.1.dev5+gf96aca45
2023.5.1.dev6+g69445c62
```

the remaining (older) package uploads can be removed with `anaconda remove`.

Most of this is taken from https://github.com/matplotlib/matplotlib/pull/23349 (c.f. https://github.com/scientific-python/upload-nightly-action/issues/4#issuecomment-1564749453).

To provide a local reproducible example of the behavior, `curl` the following attached Shell script into a `continuumio/miniconda3:latest` container with `anaconda-client` installed

<details>
<summary>example-pr-12.sh:</summary>

```bash
# example-pr-12.sh
#!/bin/bash

# fail on undefined variables
set -u
# Prevent pipe errors to be silenced
set -o pipefail
# Exit if any command exit as non-zero
set -e

# Input variables
ANACONDA_USER="scientific-python-nightly-wheels"
INPUT_ARTIFACTS_PATH="dist"
N_LATEST_UPLOADS=5

anaconda show "${ANACONDA_USER}" &> >(grep "${ANACONDA_USER}/") | \
    awk '{print $1}' | \
    sed 's|.*/||g' > package-names.txt

if [ -s package-names.txt ]; then
    while LANG=C IFS= read -r package_name ; do

        printf "\n# package: %s\n" "${package_name}"

        anaconda show "${ANACONDA_USER}/${package_name}" &> >(grep '+') | \
            awk '{print $2}' | \
            head --lines "-${N_LATEST_UPLOADS}" > remove-package-versions.txt

        if [ -s remove-package-versions.txt ]; then
            while LANG=C IFS= read -r package_version ; do
                echo "# Removing ${ANACONDA_USER}/${package_name}/${package_version}"
                # anaconda --token ${{ secrets.ANACONDA_TOKEN }} remove \
                #   --force \
                #   "${ANACONDA_USER}/${package_name}/${package_version}"
            done <remove-package-versions.txt
        fi

    done <package-names.txt
fi
```

```console
$ docker run --rm -ti continuumio/miniconda3:latest /bin/bash
(base) root@5d1ea993cbe9:/# conda install -y anaconda-client -c conda-forge
(base) root@5d1ea993cbe9:/# apt update && apt install -y curl
(base) root@5d1ea993cbe9:/# curl -sL https://github.com/scientific-python/upload-nightly-action/files/11618429/example-pr-12.sh.txt -o example-pr-12.sh
(base) root@5d1ea993cbe9:/# bash example-pr-12.sh 

# package: ipython

# package: matplotlib

# package: networkx

# package: numpy

# package: scikit-image

# package: scikit-learn

# package: scipy

# package: xarray

(base) root@5d1ea993cbe9:/# sed -i 's/N_LATEST_UPLOADS=5/N_LATEST_UPLOADS=2/g' example-pr-12.sh  # demo purposes
(base) root@5d1ea993cbe9:/# bash example-pr-12.sh

# package: ipython

# package: matplotlib
# Removing scientific-python-nightly-wheels/matplotlib/3.6.0.dev3181+g9f17f3f851
# Removing scientific-python-nightly-wheels/matplotlib/3.6.0.dev3182+gd6bad5f684

# package: networkx

# package: numpy
# Removing scientific-python-nightly-wheels/numpy/1.25.0.dev0+1532.g5d6c744db

# package: scikit-image

# package: scikit-learn

# package: scipy

# package: xarray
# Removing scientific-python-nightly-wheels/xarray/2023.5.1.dev9+g609a9016
# Removing scientific-python-nightly-wheels/xarray/2023.5.1.dev10+gf45eb733
# Removing scientific-python-nightly-wheels/xarray/2023.5.1.dev11+gfcb81756
(base) root@5d1ea993cbe9:/# 
```

</details>

[example-pr-12.sh.txt](https://github.com/scientific-python/upload-nightly-action/files/11618429/example-pr-12.sh.txt)


I'm marking this as closing Issue #4 despite that it doesn't include a time cutoff as described in https://github.com/scientific-python/upload-nightly-action/issues/4#issuecomment-1569278784 given that I do not know of a `pip` or `anaconda-client` API that gets upload date information from the index (Probably exists somewhere though?) and this PR resolves all other matters as far as I understand it. We can revise or extend this if desired.

