### PR TITLE
DOC: Advocate for using action from tagged release commit shas

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,10 @@
 # Nightly upload
 
-This provides a standard GitHub Action to upload nightly builds to the
-scientific-python nightly channel.
+This is a GitHub Action that uploads nightly builds to the [scientific-python nightly channel][],
+as recommended in [SPEC4 — Using and Creating Nightly Wheels][].
 
-In your Continuous Integration pipeline once you've built you wheel, you can
-use the following snippet to upload to our central nightly repository:
-
-<!-- c.f. https://github.com/scientific-python/upload-nightly-action/pull/13 and
-https://github.com/matplotlib/matplotlib/pull/26023#discussion_r1212539700
-for short summary of why using commit SHA -->
+In a GitHub Actions workflow (`.github/workflows/*.yaml`), use the
+following snippet to upload built wheels to the repository:
 
 ```yml
 jobs:
@@ -21,8 +17,14 @@ jobs:
         anaconda_nightly_upload_token: ${{secrets.UPLOAD_TOKEN}}
 ```
 
-It is [recommended that Dependabot is used][] to keep the GitHub Action updated
-to the latest release by using a `.github/dependabot.yml` config file similar to
+Note that we recommend pinning the action against a specific SHA
+(rather than a tag), to guard against the unlikely event of upstream
+being compromised.
+
+# Updating the action
+
+You can [use Dependabot to keep the GitHub Action up to date][],
+with a `.github/dependabot.yml` config file similar to:
 
 ```yaml
 version: 2
@@ -34,16 +36,18 @@ updates:
       interval: "weekly"
 ```
 
-To request access to the repository please open an issue on [this action
+# Access
+
+To request access to the repository, please open an issue on [this action's
 repository](https://github.com/scientific-python/upload-nightly-action). You can
 then generate a token at `https://anaconda.org/scientific-python-nightly-wheels/settings/access`
-with _Allow write access to the API site_ and _Allow uploads to Standard Python repositories_
-permissions and add the token as a secret to your GitHub repository.
+with permissions to _Allow write access to the API site_ and _Allow uploads to Standard Python repositories_,
+and add the token as a secret to your GitHub repository.
 
 # Using nightly builds in CI
 
-To test those nightly build, you can use the following command to install from
-the nightly package.
+To test against nightly builds, you can use the following command to install from
+the nightly repository:
 
 ```sh
 python -m pip install \
@@ -54,29 +58,23 @@ python -m pip install \
   matplotlib
 ```
 
-Note that `--index-url` takes priority over `--extra-index-url`.
-Packages, and dependencies, with versions available on the
-[nightly package index][] will be installed from there before falling back to
-the [Python Package Index][PyPI] to install all remaining requested packages.
+Note that `--index-url` takes priority over `--extra-index-url`, so
+that packages, and their dependencies, with versions available in the
+nightly channel will be installed before falling back to the [Python
+Package Index][PyPI].
 
-```
-if package in nightly:
-   try to install from nightly
-else:
-   try to install from pypi
-```
-
-If you want to install nightly builds within your conda environment, you can specify an
-extra index in your YML file.
+To install nightly builds within a conda environment, specify an extra
+index in your `environment.yml`:
 
 ```yml
 name: test
 dependencies:
-  - pip
   - pip:
     - --pre --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --extra-index-url https://pypi.org/simple
     - matplotlib
 ```
-[recommended that Dependabot is used]: https://learn.scientific-python.org/development/guides/gha_basic/#updating
-[nightly package index]: https://anaconda.org/scientific-python-nightly-wheels
+
+[use Dependabot to keep the GitHub Action up to date]: https://learn.scientific-python.org/development/guides/gha_basic/#updating
 [PyPI]: https://pypi.org/
+[scientific-python nightly channel]: https://anaconda.org/scientific-python-nightly-wheels
+[SPEC4 — Using and Creating Nightly Wheels]: https://scientific-python.org/specs/spec-0004/

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This provides a standard GitHub Action to upload nightly builds to the
 scientific-python nightly channel.
 
-In your Continuous Intregration pipeline once you've built you wheel, you can
+In your Continuous Integration pipeline once you've built you wheel, you can
 use the following snippet to upload to our central nightly repository:
 
 <!-- c.f. https://github.com/scientific-python/upload-nightly-action/pull/13 and

--- a/README.md
+++ b/README.md
@@ -6,15 +6,32 @@ scientific-python nightly channel.
 In your Continuous Intregration pipeline once you've built you wheel, you can
 use the following snippet to upload to our central nightly repository:
 
+<!-- c.f. https://github.com/scientific-python/upload-nightly-action/pull/13 and
+https://github.com/matplotlib/matplotlib/pull/26023#discussion_r1212539700
+for short summary of why using commit SHA -->
+
 ```yml
 jobs:
   steps:
     ...
     - name: Upload wheel
-      uses: scientific-python/upload-nightly-action@main
+      uses: scientific-python/upload-nightly-action@8f0394fd2aa0c85d7364a9958652e8994e06b23c # 0.1.0
       with:
         artifacts_path: dist
         anaconda_nightly_upload_token: ${{secrets.UPLOAD_TOKEN}}
+```
+
+It is [recommended that Dependabot is used][] to keep the GitHub Action updated
+to the latest release by using a `.github/dependabot.yml` config file similar to
+
+```yaml
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
 ```
 
 To request access to the repository please open an issue on [this action
@@ -60,6 +77,6 @@ dependencies:
     - --pre --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --extra-index-url https://pypi.org/simple
     - matplotlib
 ```
-
+[recommended that Dependabot is used]: https://learn.scientific-python.org/development/guides/gha_basic/#updating
 [nightly package index]: https://anaconda.org/scientific-python-nightly-wheels
 [PyPI]: https://pypi.org/


### PR DESCRIPTION
Resolves #7 

* For security best practices, advocate that users of the action use it from known commit shas that correspond to tagged releases.
* Advocate that users use a Dependabot config file to update the action on new tags. This will bump the commit sha and also bump the release tag in the comment of the commit sha.