### PR TITLE
In `environment.yaml`, add pip as dependency before configuring flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ index in your `environment.yml`:
 ```yml
 name: test
 dependencies:
+  - pip
   - pip:
     - --pre --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --extra-index-url https://pypi.org/simple
     - matplotlib


### PR DESCRIPTION
The previous approach works with mamba and conda, but not with micromamba. So this adds `pip` back as an explicit dependency, before configuring pip installation flags.