### PR TITLE
MNT: Use commit hash and run only on main repository

### DIFF
--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -26,7 +26,7 @@ jobs:
         touch _pass/pass.txt
 
     - name: Keep workflow alive
-      uses: peaceiris/actions-gh-pages@v3
+      uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 #v3.9.3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_branch: keep-alive

--- a/.github/workflows/remove-wheels.yml
+++ b/.github/workflows/remove-wheels.yml
@@ -23,6 +23,7 @@ jobs:
   remove:
 
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'scientific-python'
     # Set required workflow secrets in the environment for additional security
     # https://github.com/scientific-python/upload-nightly-action/settings/environments
     environment:


### PR DESCRIPTION
In follow up to https://github.com/scientific-python/upload-nightly-action/pull/18/files#r1225142853, use the commit hash for `peaceiris/actions-gh-pages` `v3.9.3`. To avoid nightly failures on the `.github/workflows/remove-wheels.yml` on forks, which lack access to

https://github.com/scientific-python/upload-nightly-action/blob/b1c5a48e464ab8a45a1899cfaefc21548923ee6d/.github/workflows/remove-wheels.yml#L74

restrict the workflow to run only on the main repository by requiring the owner be the `scientific-python` GitHub org.