### PR TITLE
ENH: Use micromamba for speed and set anaconda-client version

### DIFF
--- a/.github/workflows/remove-wheels.yml
+++ b/.github/workflows/remove-wheels.yml
@@ -36,7 +36,7 @@ jobs:
           environment-name: remove-wheels
           create-args: >-
             python=3.11
-            anaconda-client=1.11.2
+            anaconda-client=1.12.0
 
       - name: Show environment
         run: env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,10 @@
-FROM continuumio/miniconda3:latest
+FROM mambaorg/micromamba:1.4.9-bullseye-slim
+
+SHELL [ "/bin/bash", "-c" ]
+
+# Use C.UTF-8 locale to avoid issues with unicode encoding
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,11 +15,11 @@ set -x
 echo "Getting anaconda token from github secrets..."
 
 ANACONDA_ORG="scientific-python-nightly-wheels"
-ANACONDA_TOKEN="$INPUT_ANACONDA_NIGHTLY_UPLOAD_TOKEN"
+ANACONDA_TOKEN="${INPUT_ANACONDA_NIGHTLY_UPLOAD_TOKEN}"
 
 # if the ANACONDA_TOKEN is empty, exit with status -1
 # this is to prevent accidental uploads
-if [ -z "$ANACONDA_TOKEN" ]; then
+if [ -z "${ANACONDA_TOKEN}" ]; then
   echo "ANACONDA_TOKEN is empty , exiting..."
   exit -1
 fi
@@ -43,5 +43,8 @@ env
 # upload wheels
 echo "Uploading wheels to anaconda.org..."
 
-anaconda -t $ANACONDA_TOKEN upload --force -u "$ANACONDA_ORG" "$INPUT_ARTIFACTS_PATH"/*.whl
-echo "Index: https://pypi.anaconda.org/$ANACONDA_ORG/simple"
+anaconda --token "${ANACONDA_TOKEN}" upload \
+  --force \
+  --user "${ANACONDA_ORG}" \
+  "${INPUT_ARTIFACTS_PATH}"/*.whl
+echo "Index: https://pypi.anaconda.org/${ANACONDA_ORG}/simple"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,7 +27,10 @@ fi
 # install anaconda-client
 echo "Installing anaconda-client..."
 
-conda install -y anaconda-client -c conda-forge
+micromamba install \
+  --yes \
+  --channel conda-forge \
+  "anaconda-client"
 
 # trim trailing slashes from $INPUT_ARTIFACTS_PATH
 INPUT_ARTIFACTS_PATH="${INPUT_ARTIFACTS_PATH%/}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,13 +24,15 @@ if [ -z "$ANACONDA_TOKEN" ]; then
   exit -1
 fi
 
+export ANACONDA_CLIENT_VERSION="1.12.0"
+
 # install anaconda-client
-echo "Installing anaconda-client..."
+echo "Installing anaconda-client v${ANACONDA_CLIENT_VERSION}..."
 
 micromamba install \
   --yes \
   --channel conda-forge \
-  "anaconda-client"
+  "anaconda-client==${ANACONDA_CLIENT_VERSION}"
 
 # trim trailing slashes from $INPUT_ARTIFACTS_PATH
 INPUT_ARTIFACTS_PATH="${INPUT_ARTIFACTS_PATH%/}"


### PR DESCRIPTION
High level summary:

* Use micromamba for speed.
* Configure Docker image environment for shell environment stability.
* Explicitly set anaconda-client version for reproducibility and security. (This should ideally be a lock file but one thing at a time).