### PR TITLE
CI: Add test workflow for action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,78 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  # Run weekly at 1:23 UTC
+  schedule:
+  - cron:  '23 1 * * 0'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: "test upload via action"
+    runs-on: ubuntu-latest
+    if: github.repository == 'scientific-python/upload-nightly-action'
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Install python-build and twine
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build twine
+          python -m pip list
+
+      - name: Build a wheel and a sdist
+        run: |
+          PYTHONWARNINGS=error,default::DeprecationWarning python -m build --outdir ./dist tests/test_package
+
+      - name: Verify the distribution
+        run: twine check --strict dist/*
+
+      - name: List contents of sdist
+        run: python -m tarfile --list dist/test-package-*.tar.gz
+
+      - name: List contents of wheel
+        run: python -m zipfile --list dist/test_package-*.whl
+
+      - name: Test upload
+        uses: ./
+        with:
+          artifacts_path: dist
+          anaconda_nightly_upload_token: ${{ secrets.UPLOAD_TOKEN }}
+
+  cleanup:
+    runs-on: ubuntu-latest
+    needs: [test]
+    # Set required workflow secrets in the environment for additional security
+    # https://github.com/scientific-python/upload-nightly-action/settings/environments
+    environment:
+      name: remove-old-wheels
+
+    steps:
+      - name: Install micromamba and anaconda-client
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          environment-name: remove-wheels
+          create-args: >-
+            python=3.11
+            anaconda-client
+
+      - name: Remove test package upload
+        shell: bash -l {0}
+        run: |
+            anaconda --token ${{ secrets.ANACONDA_TOKEN }} remove \
+              --force \
+              "scientific-python-nightly-wheels/test-package"

--- a/tests/test_package/README.md
+++ b/tests/test_package/README.md
@@ -1,0 +1,1 @@
+# Test README

--- a/tests/test_package/pyproject.toml
+++ b/tests/test_package/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "test-package"
+version = "0.0.1"
+authors = [
+  { name="Scientifc Python Developers", email="null@example.com" },
+]
+description = "Test project for testing GitHub Action"
+readme = "README.md"
+requires-python = ">=3.8"


### PR DESCRIPTION
Resolves #15 

* Add simplest example package to tests so that it can be built for upload to Anaconda cloud as a test of the action.
   - Use `setuptools` as the build backend over something like `hatchling` given the simple nature of the `test-package` given that `anaconda-client` `v1.12.0` doesn't understand valid metadata from PEP 518 build backends other than `setuptools`. c.f. https://github.com/Anaconda-Platform/anaconda-client/issues/676

* Add CI GitHub Action workflow to test the functionality of the action as shown in the README.

https://github.com/scientific-python/upload-nightly-action/blob/4792bc241c0a689e41f0fc4bf0953f26b8324c7b/README.md?plain=1#L10-L17