### PR TITLE
MNT: Align version metadata with git tag

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ permissions:
   contents: read
   metadata: read
 author: "Scientific-Python"
-version: "1.0.0"
+version: "0.1.0"
 
 inputs:
   artifacts_path:


### PR DESCRIPTION
* The latest repository tag is [`0.1.0`](https://github.com/scientific-python/upload-nightly-action/releases/tag/0.1.0) and so the action version metadata should reflect that as well.