### PR TITLE
CI: Remove package versions older than 30 days

### DIFF
--- a/.github/workflows/remove-wheels.yml
+++ b/.github/workflows/remove-wheels.yml
@@ -72,8 +72,6 @@ jobs:
                       jq -r '.releases[].version' > package-versions.txt
                   head --lines "-${N_LATEST_UPLOADS}" package-versions.txt > remove-package-versions.txt
 
-                  # Don't need to check for duplicate versions added to removal
-                  # given nightly CRON basis.
                   for package_version in $(cat package-versions.txt); do
                     # c.f. https://github.com/Anaconda-Platform/anaconda-client/issues/682#issuecomment-1677283067
                     upload_date=$(curl --silent https://api.anaconda.org/release/"${ANACONDA_USER}/${package_name}/${package_version}" | \
@@ -89,6 +87,10 @@ jobs:
                   done
 
                   if [ -s remove-package-versions.txt ]; then
+                      # Guard against duplicate entries from packages over
+                      # count and time thresholds
+                      sort --output remove-package-versions.txt --unique remove-package-versions.txt
+
                       for package_version in $(cat remove-package-versions.txt); do
                           echo "# Removing ${ANACONDA_USER}/${package_name}/${package_version}"
                           anaconda --token ${{ secrets.ANACONDA_TOKEN }} remove \

--- a/.github/workflows/remove-wheels.yml
+++ b/.github/workflows/remove-wheels.yml
@@ -37,6 +37,8 @@ jobs:
           create-args: >-
             python=3.11
             anaconda-client=1.12.0
+            curl
+            jq
 
       - name: Show environment
         run: env
@@ -55,19 +57,36 @@ jobs:
 
       - name: Remove old uploads to save space
         run: |
-          # Remove all _but_ the last ${N_LATEST_UPLOADS} package versions
-          # N.B.: `anaconda show` places the newest packages at the bottom of the output
-          # of the 'Versions' section and package versions are preceded with a '   + '.
+          # Remove all _but_ the last ${N_LATEST_UPLOADS} package versions and
+          # remove all package versions older than 30 days.
 
           if [ -s package-names.txt ]; then
+              threshold_date="$(date +%F -d '30 days ago')"
+
               # Remember can't quote subshell as need to split on (space seperated) token
               for package_name in $(cat package-names.txt); do
 
                   echo -e "\n# package: ${package_name}"
 
-                  anaconda show "${ANACONDA_USER}/${package_name}" &> >(grep '+') | \
-                      awk '{print $2}' | \
-                      head --lines "-${N_LATEST_UPLOADS}" > remove-package-versions.txt
+                  curl --silent https://api.anaconda.org/package/"${ANACONDA_USER}/${package_name}" | \
+                      jq -r '.releases[].version' > package-versions.txt
+                  head --lines "-${N_LATEST_UPLOADS}" package-versions.txt > remove-package-versions.txt
+
+                  # Don't need to check for duplicate versions added to removal
+                  # given nightly CRON basis.
+                  for package_version in $(cat package-versions.txt); do
+                    # c.f. https://github.com/Anaconda-Platform/anaconda-client/issues/682#issuecomment-1677283067
+                    upload_date=$(curl --silent https://api.anaconda.org/release/"${ANACONDA_USER}/${package_name}/${package_version}" | \
+                        jq -r '.distributions[].upload_time' | \
+                        sort | \
+                        tail --lines 1 | \
+                        awk '{print $1}')
+
+                    if [[ "${upload_date}" < "${threshold_date}" ]]; then
+                        echo "# ${ANACONDA_USER}/${package_name}/${package_version} last uploaded on ${upload_date}"
+                        echo "${package_version}" >> remove-package-versions.txt
+                    fi
+                  done
 
                   if [ -s remove-package-versions.txt ]; then
                       for package_version in $(cat remove-package-versions.txt); do


### PR DESCRIPTION
Resolves #31 

* Add curl and jq to environment requirements.
* Use output from the anaconda.org API to get latest upload time for each release of a package. If the upload date is older than 30 days add the package release for removal.
* Use anaconda.org API over anaconda-client CLI API to get package versions as easier to understand.

Running this now (with the remove step commented out) gives

```
# package: ipython
# scientific-python-nightly-wheels/ipython/8.13.2 last uploaded on 2023-05-26
# scientific-python-nightly-wheels/ipython/8.14.0.dev0 last uploaded on 2023-05-28
# Removing scientific-python-nightly-wheels/ipython/8.13.2
# Removing scientific-python-nightly-wheels/ipython/8.14.0.dev0

# package: matplotlib

# package: networkx

# package: numpy
# scientific-python-nightly-wheels/numpy/1.25.0rc1+93.g95343a3e6 last uploaded on 
# scientific-python-nightly-wheels/numpy/1.25.0rc1+104.g19f86c318 last uploaded on 
# scientific-python-nightly-wheels/numpy/1.25.0rc1+140.g2a243e698 last uploaded on 
# scientific-python-nightly-wheels/numpy/1.25.0rc1+218.g0e5a362fd last uploaded on 
# Removing scientific-python-nightly-wheels/numpy/1.25.0rc1+93.g95343a3e6
# Removing scientific-python-nightly-wheels/numpy/1.25.0rc1+104.g19f86c318
# Removing scientific-python-nightly-wheels/numpy/1.25.0rc1+140.g2a243e698
# Removing scientific-python-nightly-wheels/numpy/1.25.0rc1+218.g0e5a362fd

# package: openblas-libs

# package: pandas
# Removing scientific-python-nightly-wheels/pandas/2.1.0.dev0+1429.gcf741a492e

# package: scikit-image
# scientific-python-nightly-wheels/scikit-image/0.21.0rc2.dev0 last uploaded on 2023-05-28
# Removing scientific-python-nightly-wheels/scikit-image/0.21.0rc2.dev0

# package: scikit-learn
# scientific-python-nightly-wheels/scikit-learn/1.2.2 last uploaded on 2023-05-31
# Removing scientific-python-nightly-wheels/scikit-learn/1.2.2

# package: scipy
# scientific-python-nightly-wheels/scipy/1.10.1 last uploaded on 
# Removing scientific-python-nightly-wheels/scipy/1.10.1

# package: statsmodels
# scientific-python-nightly-wheels/statsmodels/0.14.0 last uploaded on 2023-06-04
# scientific-python-nightly-wheels/statsmodels/0.15.0.dev30+gfdd13b464 last uploaded on 2023-06-29
# Removing scientific-python-nightly-wheels/statsmodels/0.14.0
# Removing scientific-python-nightly-wheels/statsmodels/0.15.0.dev30+gfdd13b464

# package: xarray
```

With regards to why the `numpy` `v1.25.0rc1` and `scipy` `v1.10.1` distributions are missing a last uploaded date c.f. https://github.com/Anaconda-Platform/anaconda-client/issues/682#issuecomment-1677699898