### PR TITLE
ENH: adding list of packages to exclude from cleanup

### DIFF
--- a/.github/workflows/remove-wheels.yml
+++ b/.github/workflows/remove-wheels.yml
@@ -51,9 +51,11 @@ jobs:
 
       - name: Query package index for packages
         run: |
+          curl https://raw.githubusercontent.com/scientific-python/upload-nightly-action/main/packages-ignore-from-cleanup.txt --output packages-ignore-from-cleanup.txt
           anaconda show "${ANACONDA_USER}" &> >(grep "${ANACONDA_USER}/") | \
               awk '{print $1}' | \
-              sed 's|.*/||g' > package-names.txt
+              sed 's|.*/||g' | \
+              grep -vf packages-ignore-from-cleanup.txt > package-names.txt
 
       - name: Remove old uploads to save space
         run: |

--- a/packages-ignore-from-cleanup.txt
+++ b/packages-ignore-from-cleanup.txt
@@ -1,0 +1,1 @@
+openblas-libs


### PR DESCRIPTION
This is to add a file to host the agreed upon exceptions for the cleanups. Neither the number version nor the date based cleanup will run for these.


CI is expected to fail as 
Fixes #34 

cc @mattip