### PR TITLE
ENH: Add optional `anaconda_nightly_upload_organization` argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ and add the token as a secret to your GitHub repository.
 ## Using a different channel
 
 This Github Action can upload your nightly builds to a different channel. To do so,
-you will required to define  `anaconda_nightly_upload_url` variable. Furthermore,
-you can define the labels to use for organizing your artifacts by using `anaconda_nightly_upload_labels`
+define the `anaconda_nightly_upload_url` variable. Furthermore,
+you can add labels for organizing your artifacts using `anaconda_nightly_upload_labels`
 optional parameter. See below:
 
 ```yml

--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ and add the token as a secret to your GitHub repository.
 ## Using a different channel
 
 This Github Action can upload your nightly builds to a different channel. To do so,
-you will required to define  `anaconda_nightly_upload_url` variable. See below:
+you will required to define  `anaconda_nightly_upload_url` variable. Furthermore,
+you can define the labels to use for organizing your artifacts by using `anaconda_nightly_upload_labels`
+optional parameter. See below:
 
 ```yml
 jobs:
@@ -59,6 +61,7 @@ jobs:
         artifacts_path: dist
         anaconda_nightly_upload_url: my-alternative-scientific-channel
         anaconda_nightly_upload_token: ${{secrets.UPLOAD_TOKEN}}
+        anaconda_nightly_upload_labels: main
 ```
 
 ## Artifact cleanup-policy at the ``scientific-python-nightly-wheels`` channel

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ and add the token as a secret to your GitHub repository.
 ## Using a different channel
 
 This Github Action can upload your nightly builds to a different channel. To do so,
-define the `anaconda_nightly_upload_url` variable. Furthermore,
+define the `anaconda_nightly_upload_organization` variable. Furthermore,
 you can add labels for organizing your artifacts using `anaconda_nightly_upload_labels`
 optional parameter. See below:
 
@@ -59,9 +59,9 @@ jobs:
       uses: scientific-python/upload-nightly-action@5fb764c5bce1ac2297084c0f7161b1919f17c74f # 0.2.0
       with:
         artifacts_path: dist
-        anaconda_nightly_upload_url: my-alternative-scientific-channel
+        anaconda_nightly_upload_organization: my-alternative-organization
         anaconda_nightly_upload_token: ${{secrets.UPLOAD_TOKEN}}
-        anaconda_nightly_upload_labels: main
+        anaconda_nightly_upload_labels: dev
 ```
 
 ## Artifact cleanup-policy at the ``scientific-python-nightly-wheels`` channel

--- a/README.md
+++ b/README.md
@@ -44,6 +44,23 @@ then generate a token at `https://anaconda.org/scientific-python-nightly-wheels/
 with permissions to _Allow write access to the API site_ and _Allow uploads to Standard Python repositories_,
 and add the token as a secret to your GitHub repository.
 
+## Using a different channel
+
+This Github Action can upload your nightly builds to a different channel. To do so,
+you will required to define  `anaconda_nightly_upload_url` variable. See below:
+
+```yml
+jobs:
+  steps:
+    ...
+    - name: Upload wheel
+      uses: scientific-python/upload-nightly-action@5fb764c5bce1ac2297084c0f7161b1919f17c74f # 0.2.0
+      with:
+        artifacts_path: dist
+        anaconda_nightly_upload_url: my-alternative-scientific-channel
+        anaconda_nightly_upload_token: ${{secrets.UPLOAD_TOKEN}}
+```
+
 ## Artifact cleanup-policy at the ``scientific-python-nightly-wheels`` channel
 
 To avoid hosting outdated development versions, as well as to clean up space, we do have a

--- a/action.yml
+++ b/action.yml
@@ -14,8 +14,8 @@ inputs:
   anaconda_nightly_upload_token:
     description: 'Token to upload to scientific python org'
     required: true
-  anaconda_nightly_upload_url:
-    description: 'URL of the index to upload the wheels to'
+  anaconda_nightly_upload_organization:
+    description: 'Organisation name to upload the wheels to'
     required: false
     default: scientific-python-nightly-wheels
   anaconda_nightly_upload_labels:

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ inputs:
     required: false
     default: scientific-python-nightly-wheels
   anaconda_nightly_upload_labels:
-    description: 'Labels assigned to the uploaded artifacts'
+    description: 'List of labels assigned to the uploaded artifacts'
     required: false
     default: main
 

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,14 @@ inputs:
   anaconda_nightly_upload_token:
     description: 'Token to upload to scientific python org'
     required: true
+  anaconda_nightly_upload_url:
+    description: 'URL to upload to scientific python org'
+    required: false
+    default: scientific-python-nightly-wheels
+  anaconda_nightly_upload_labels:
+    description: 'Labels assigned to the uploaded artifacts'
+    required: false
+    default: main
 
 runs:
   using: 'docker'

--- a/action.yml
+++ b/action.yml
@@ -15,13 +15,13 @@ inputs:
     description: 'Token to upload to scientific python org'
     required: true
   anaconda_nightly_upload_url:
-    description: 'URL to upload to scientific python org'
+    description: 'URL of the index to upload the wheels to'
     required: false
     default: scientific-python-nightly-wheels
   anaconda_nightly_upload_labels:
     description: 'Labels assigned to the uploaded artifacts'
     required: false
-    default: main
+    default: [main]
 
 runs:
   using: 'docker'

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ inputs:
   anaconda_nightly_upload_labels:
     description: 'Labels assigned to the uploaded artifacts'
     required: false
-    default: [main]
+    default: main
 
 runs:
   using: 'docker'

--- a/cmd.sh
+++ b/cmd.sh
@@ -21,7 +21,7 @@ ANACONDA_LABELS="${INPUT_ANACONDA_NIGHTLY_UPLOAD_LABELS}"
 # if the ANACONDA_ORG is empty, exit with status -1
 # this is to prevent attempt to upload to the wrong anaconda channel
 if [ -z "${ANACONDA_ORG}" ]; then
-  echo "ANACONDA_ORG is empty , exiting..."
+  echo "ANACONDA_ORG is empty, exiting..."
   exit -1
 fi
 
@@ -33,23 +33,24 @@ if [ -z "${ANACONDA_TOKEN}" ]; then
   exit -1
 fi
 
+# if the ANACONDA_LABELS is empty, exit with status -1
+# as this should be set in action.yml or by the user
+# and it is better to fail on this to sigal a problem.
 if [ -z "${ANACONDA_LABELS}" ]; then
-  echo "ANACONDA_LABELS is empty , using default label (main)..."
-  ANACONDA_LABELS="--label main"
-else
-  # Count the number of words in the string
-  label_count=$(echo "$ANACONDA_LABELS" | wc -w)
-  if [ "$label_count" -gt 1 ]; then
-    formatted_labels=""
-    for label in ${ANACONDA_LABELS}; do
-      formatted_labels+="--label $label "
-    done
-    ANACONDA_LABELS="${formatted_labels}"
-  else
-    ANACONDA_LABELS="--label $ANACONDA_LABELS"
-    echo "only 1 label, using option: $ANACONDA_LABELS"
-  fi
+  echo "ANACONDA_LABELS is empty, exiting..."
+  exit -1
 fi
+
+# convert newlines to commas for parsing
+# and ensure that there is no trailing comma
+ANACONDA_LABELS="$(tr '\n' ',' <<< "${ANACONDA_LABELS}" | sed 's/,$//')"
+
+IFS=',' read -ra LABELS <<< "${ANACONDA_LABELS}"
+
+LABEL_ARGS=""
+for label in "${LABELS[@]}"; do
+  LABEL_ARGS+="--label ${label} "
+done
 
 # Install anaconda-client from lock file
 echo "Installing anaconda-client from upload-nightly-action conda-lock lock file..."

--- a/cmd.sh
+++ b/cmd.sh
@@ -33,6 +33,24 @@ if [ -z "${ANACONDA_TOKEN}" ]; then
   exit -1
 fi
 
+if [ -z "${ANACONDA_LABELS}" ]; then
+  echo "ANACONDA_LABELS is empty , using default label (main)..."
+  ANACONDA_LABELS="--label main"
+else
+  # Count the number of words in the string
+  label_count=$(echo "$ANACONDA_LABELS" | wc -w)
+  if [ "$label_count" -gt 1 ]; then
+    formatted_labels=""
+    for label in ${ANACONDA_LABELS}; do
+      formatted_labels+="--label $label "
+    done
+    ANACONDA_LABELS="${formatted_labels}"
+  else
+    ANACONDA_LABELS="--label $ANACONDA_LABELS"
+    echo "only 1 label, using option: $ANACONDA_LABELS"
+  fi
+fi
+
 # Install anaconda-client from lock file
 echo "Installing anaconda-client from upload-nightly-action conda-lock lock file..."
 micromamba create \
@@ -57,6 +75,6 @@ echo "Uploading wheels to anaconda.org..."
 anaconda --token "${ANACONDA_TOKEN}" upload \
   --force \
   --user "${ANACONDA_ORG}" \
-  --label "${ANACONDA_LABELS}" \
+  $ANACONDA_LABELS \
   "${INPUT_ARTIFACTS_PATH}"/*.whl
 echo "Index: https://pypi.anaconda.org/${ANACONDA_ORG}/simple"

--- a/cmd.sh
+++ b/cmd.sh
@@ -14,9 +14,17 @@ set -x
 # this is to prevent accidental uploads
 echo "Getting anaconda token from github secrets..."
 
-ANACONDA_ORG="${INPUT_ANACONDA_NIGHTLY_UPLOAD_URL}"
+ANACONDA_ORG="${INPUT_ANACONDA_NIGHTLY_UPLOAD_ORGANIZATION}"
 ANACONDA_TOKEN="${INPUT_ANACONDA_NIGHTLY_UPLOAD_TOKEN}"
 ANACONDA_LABELS="${INPUT_ANACONDA_NIGHTLY_UPLOAD_LABELS}"
+
+# if the ANACONDA_ORG is empty, exit with status -1
+# this is to prevent attempt to upload to the wrong anaconda channel
+if [ -z "${ANACONDA_ORG}" ]; then
+  echo "ANACONDA_ORG is empty , exiting..."
+  exit -1
+fi
+
 
 # if the ANACONDA_TOKEN is empty, exit with status -1
 # this is to prevent accidental uploads

--- a/cmd.sh
+++ b/cmd.sh
@@ -14,8 +14,9 @@ set -x
 # this is to prevent accidental uploads
 echo "Getting anaconda token from github secrets..."
 
-ANACONDA_ORG="scientific-python-nightly-wheels"
+ANACONDA_ORG="${INPUT_ANACONDA_NIGHTLY_UPLOAD_URL}"
 ANACONDA_TOKEN="${INPUT_ANACONDA_NIGHTLY_UPLOAD_TOKEN}"
+ANACONDA_LABELS="${INPUT_ANACONDA_NIGHTLY_UPLOAD_LABELS}"
 
 # if the ANACONDA_TOKEN is empty, exit with status -1
 # this is to prevent accidental uploads
@@ -48,5 +49,6 @@ echo "Uploading wheels to anaconda.org..."
 anaconda --token "${ANACONDA_TOKEN}" upload \
   --force \
   --user "${ANACONDA_ORG}" \
+  --label "${ANACONDA_LABELS}" \
   "${INPUT_ARTIFACTS_PATH}"/*.whl
 echo "Index: https://pypi.anaconda.org/${ANACONDA_ORG}/simple"


### PR DESCRIPTION
This is a follow up and fixes #46

This PR goal is to allow other Scientific Python projects to use this github action.

Please, let me know what you think, and I will be happy to rename the variables if needed.

Thanks  

**Squash and merge commit**

```
* Add optional `anaconda_nightly_upload_organization` and
  `anaconda_nightly_upload_labels` arguments to allow for packages
  to be uploaded to custom registires with the GitHub Action.
* Add docs to README providing an example of how to upload to an
  alternative registry.
```