### PR TITLE
FIX: Use correct shell variable in upload

### DIFF
--- a/cmd.sh
+++ b/cmd.sh
@@ -73,9 +73,11 @@ env
 # upload wheels
 echo "Uploading wheels to anaconda.org..."
 
+# Note: ${LABEL_ARGS} must not be quoted during shell parameter expansion,
+# else it will be treated as a file and not additional command arguments.
 anaconda --token "${ANACONDA_TOKEN}" upload \
   --force \
   --user "${ANACONDA_ORG}" \
-  $ANACONDA_LABELS \
+  ${LABEL_ARGS} \
   "${INPUT_ARTIFACTS_PATH}"/*.whl
 echo "Index: https://pypi.anaconda.org/${ANACONDA_ORG}/simple"


### PR DESCRIPTION
Resolves #52 

* Use the correct shell variable "LABEL_ARGS" to pass the lable args to the `anaconda upload` command.
   - Amends PR https://github.com/scientific-python/upload-nightly-action/pull/47
* Note that it is important that `${LABEL_ARGS}` is NOT quoted during shell parameter expansion, else it will be treated as a file path to anaconda upload and not an argument.
   - e.g. This will trigger `File "--label main " does not exist` errors.