### PR TITLE
CI: Add test for uploads with multiple labels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
           artifacts_path: dist
           anaconda_nightly_upload_token: ${{ secrets.UPLOAD_TOKEN }}
 
-      - name: Build a wheel and a sdist
+      - name: Build v0.0.2 wheel and sdist
         run: |
           # Bump version to avoid wheel name conflicts
           sed -i 's/0.0.1/0.0.2/g' tests/test_package/pyproject.toml
@@ -67,7 +67,7 @@ jobs:
           anaconda_nightly_upload_token: ${{ secrets.UPLOAD_TOKEN }}
           anaconda_nightly_upload_labels: test
 
-      - name: Build a wheel and a sdist
+      - name: Build v0.0.3 wheel and sdist
         run: |
           # Bump version to avoid wheel name conflicts
           sed -i 's/0.0.2/0.0.3/g' tests/test_package/pyproject.toml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Build a wheel and a sdist
         run: |
-          PYTHONWARNINGS=error,default::DeprecationWarning python -m build --outdir ./dist tests/test_package
+          python -m build --outdir ./dist tests/test_package
 
       - name: Verify the distribution
         run: twine check --strict dist/*
@@ -52,6 +52,34 @@ jobs:
         with:
           artifacts_path: dist
           anaconda_nightly_upload_token: ${{ secrets.UPLOAD_TOKEN }}
+
+      - name: Build a wheel and a sdist
+        run: |
+          # Bump version to avoid wheel name conflicts
+          sed -i 's/0.0.1/0.0.2/g' tests/test_package/pyproject.toml
+          rm ./dist/*
+          python -m build --outdir ./dist tests/test_package
+
+      - name: Test upload with non-main label
+        uses: ./
+        with:
+          artifacts_path: dist
+          anaconda_nightly_upload_token: ${{ secrets.UPLOAD_TOKEN }}
+          anaconda_nightly_upload_labels: test
+
+      - name: Build a wheel and a sdist
+        run: |
+          # Bump version to avoid wheel name conflicts
+          sed -i 's/0.0.2/0.0.3/g' tests/test_package/pyproject.toml
+          rm ./dist/*
+          python -m build --outdir ./dist tests/test_package
+
+      - name: Test upload with multiple labels
+        uses: ./
+        with:
+          artifacts_path: dist
+          anaconda_nightly_upload_token: ${{ secrets.UPLOAD_TOKEN }}
+          anaconda_nightly_upload_labels: dev,test
 
   cleanup:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
           python -m pip install build twine
           python -m pip list
 
-      - name: Build a wheel and a sdist
+      - name: Build v0.0.1 wheel and sdist
         run: |
           python -m build --outdir ./dist tests/test_package
 


### PR DESCRIPTION
Add test uploads for non-main label 'test' and for multiple labels in a comma seperated list to compliment the feature added in PR #47.

This is an example of things working as intended prior to the cleanup step removing the test package.

![pre-clean-up](https://github.com/scientific-python/upload-nightly-action/assets/5142394/529535d1-2a59-4e3d-9292-a747693488bc)
