### PR TITLE
FIX: Remove environment print for security

### DIFF
--- a/cmd.sh
+++ b/cmd.sh
@@ -67,9 +67,6 @@ micromamba activate upload-nightly-action
 # trim trailing slashes from $INPUT_ARTIFACTS_PATH
 INPUT_ARTIFACTS_PATH="${INPUT_ARTIFACTS_PATH%/}"
 
-# debug, print env
-env
-
 # upload wheels
 echo "Uploading wheels to anaconda.org..."
 


### PR DESCRIPTION
* As 'env' prints the entire environment this is a route to accidentally leak secrets into public logs. While GitHub properly screens secrets

e.g.
```
...
LANG=C.UTF-8
RUNNER_ARCH=X64
RUNNER_TEMP=/home/runner/work/_temp
INPUT_ANACONDA_NIGHTLY_UPLOAD_TOKEN=***
ACTIONS_RUNTIME_URL=https://pipelinesghubeus12.actions.githubusercontent.com/qHNE2myTV4smS5AnZY3ul8hK3jNsaMgPRnYT5KDbQp06Cln8tW/
CONDA_PROMPT_MODIFIER=(upload-nightly-action) 
...
```

it would be better to not provide a chance for something to go wrong.
* Amends 8f0394fd2aa0c85d7364a9958652e8994e06b23c