### PR TITLE
DOC: Update action commit SHA to the 0.3.0 tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ jobs:
   steps:
     ...
     - name: Upload wheel
-      uses: scientific-python/upload-nightly-action@5fb764c5bce1ac2297084c0f7161b1919f17c74f # 0.2.0
+      uses: scientific-python/upload-nightly-action@6e9304f7a3a5501c6f98351537493ec898728299 # 0.3.0
       with:
         artifacts_path: dist
         anaconda_nightly_upload_token: ${{secrets.UPLOAD_TOKEN}}
@@ -56,7 +56,7 @@ jobs:
   steps:
     ...
     - name: Upload wheel
-      uses: scientific-python/upload-nightly-action@5fb764c5bce1ac2297084c0f7161b1919f17c74f # 0.2.0
+      uses: scientific-python/upload-nightly-action@6e9304f7a3a5501c6f98351537493ec898728299 # 0.3.0
       with:
         artifacts_path: dist
         anaconda_nightly_upload_organization: my-alternative-organization


### PR DESCRIPTION
* For stability provide the commit SHA (6e9304f7a3a5501c6f98351537493ec898728299) that corresponds to the 0.3.0 tag for users to pin to.