### PR TITLE
CI: fix spelling of test package name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         run: twine check --strict dist/*
 
       - name: List contents of sdist
-        run: python -m tarfile --list dist/test-package-*.tar.gz
+        run: python -m tarfile --list dist/test_package-*.tar.gz
 
       - name: List contents of wheel
         run: python -m zipfile --list dist/test_package-*.whl


### PR DESCRIPTION
`python -m build --outdir ./dist tests/test_package` now creates `test_package-0.0.1.tar.gz` and `test_package-0.0.1-py3-none-any.whl` thus this PR fixes the spelling for the CI to pass.