### PR TITLE
docs: Correct token url to user account

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ updates:
 
 To request access to the wheel channel, please open an issue on [the upload action's
 repository](https://github.com/scientific-python/upload-nightly-action). You can
-then generate a token at `https://anaconda.org/scientific-python-nightly-wheels/settings/access`
+then generate a token at `https://anaconda.org/<anaconda cloud user name>/settings/access`
 with permissions to _Allow write access to the API site_ and _Allow uploads to Standard Python repositories_,
 and add the token as a secret to your GitHub repository.
 


### PR DESCRIPTION
Address typo noticed in https://github.com/apache/arrow/issues/40216#issuecomment-2315175755.

Users of the action should generate an access token from their own Anaconda Cloud account, not from the Scientific Python organisation's account.