### PR TITLE
TST: Use hatchling as build backend for test project

### DIFF
--- a/tests/test_package/pyproject.toml
+++ b/tests/test_package/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["setuptools>=61.0"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
 [project]
 name = "test-package"


### PR DESCRIPTION
* As the test project does not need any part of setuptools specific infrastructure, use hatchling as the build backend.
* This is possible now that https://github.com/anaconda/anaconda-client/issues/676 has been resolved. c.f. https://github.com/scientific-python/upload-nightly-action/pull/27 for more information.