### PR TITLE
FIX: Use $GITHUB_ACTION_PATH to locate pixi.lock for downstream users

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -45,4 +45,4 @@ runs:
         INPUT_ANACONDA_NIGHTLY_UPLOAD_TOKEN: ${{ inputs.anaconda_nightly_upload_token }}
         INPUT_ANACONDA_NIGHTLY_UPLOAD_LABELS: ${{ inputs.anaconda_nightly_upload_labels }}
       run: |
-        pixi run $GITHUB_ACTION_PATH/upload_wheels.sh
+        pixi run ${{ github.action_path }}/upload_wheels.sh

--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,7 @@ runs:
         # Avoid post cleanup errors if action run multiple times
         post-cleanup: false
         # Action consumers should load the lock file from the action repo
-        manifest-path: $GITHUB_ACTION_PATH/pixi.toml
+        manifest-path: ${{ github.action_path }}/pixi.toml
 
     - name: Upload wheels
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -34,6 +34,8 @@ runs:
         cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
         # Avoid post cleanup errors if action run multiple times
         post-cleanup: false
+        # Action consumers should load the lock file from the action repo
+        manifest-path: $GITHUB_ACTION_PATH
 
     - name: Upload wheels
       shell: bash
@@ -43,4 +45,4 @@ runs:
         INPUT_ANACONDA_NIGHTLY_UPLOAD_TOKEN: ${{ inputs.anaconda_nightly_upload_token }}
         INPUT_ANACONDA_NIGHTLY_UPLOAD_LABELS: ${{ inputs.anaconda_nightly_upload_labels }}
       run: |
-        pixi run upload_wheels.sh
+        pixi run $GITHUB_ACTION_PATH/upload_wheels.sh

--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,7 @@ runs:
         # Avoid post cleanup errors if action run multiple times
         post-cleanup: false
         # Action consumers should load the lock file from the action repo
-        manifest-path: $GITHUB_ACTION_PATH
+        manifest-path: $GITHUB_ACTION_PATH/pixi.toml
 
     - name: Upload wheels
       shell: bash


### PR DESCRIPTION
I'm not sure, but I think with the change to composite action we need to also be specific about this repo's filepaths by using `GITHUB_ACTION_PATH` . I tried to use `0.6.0` downstream and I got an error `Failed to generate cache key: Error: ENOENT: no such file or directory, open 'pixi.lock'

## Squash and merge commit message
```
* As the GitHub Action is being used in other workflows, it does not know the
  local filepaths and so to have prefix-dev/setup-pixi find the lock file and
  'pixi run' know where `upload_wheels.sh` is, the environmental variable
  'GITHUB_ACTION_PATH' is used through the ${{ github.action_path }} context.
   - c.f. https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables
```