### PR TITLE
MAINT: Need to be explicit with action path while using pixi run too

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -45,4 +45,4 @@ runs:
         INPUT_ANACONDA_NIGHTLY_UPLOAD_TOKEN: ${{ inputs.anaconda_nightly_upload_token }}
         INPUT_ANACONDA_NIGHTLY_UPLOAD_LABELS: ${{ inputs.anaconda_nightly_upload_labels }}
       run: |
-        pixi run ${{ github.action_path }}/upload_wheels.sh
+        pixi run --manifest-path ${{ github.action_path }}/pixi.toml ${{ github.action_path }}/upload_wheels.sh


### PR DESCRIPTION
I missed this in https://github.com/scientific-python/upload-nightly-action/pull/96 but we need to be explicit while using `pixi run` too.

I was tripping into `could not find pixi.toml or pyproject.toml which is configured to use pixi` while on the `pixi run` step downstream.

I can use https://github.com/scipp/scipp/pull/3542 to test this outside of this repo. I'll ping here once that passes :)

```
* Provide '--manifest-path' option to 'pixi run' to ensure the environment is properly activated.

      --manifest-path <MANIFEST_PATH>
          The path to 'pixi.toml' or 'pyproject.toml'
```