### PR TITLE
CI: Use 'uv tool run' for build and twine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,18 +31,15 @@ jobs:
         with:
           python-version: '3.x'
 
-      - name: Install python-build and twine
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install build twine
-          python -m pip list
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v3
 
       - name: Build v0.0.1 wheel and sdist
         run: |
-          python -m build --outdir ./dist _action_path/tests/test_package
+          uv tool run --from build pyproject-build --installer=uv --outdir ./dist _action_path/tests/test_package
 
       - name: Verify the distribution
-        run: twine check --strict dist/*
+        run: uv tool run twine check --strict dist/*
 
       - name: List contents of sdist
         run: python -m tarfile --list dist/test_package-*.tar.gz
@@ -67,7 +64,7 @@ jobs:
           # Bump version to avoid wheel name conflicts
           sed -i 's/0.0.1/0.0.2/g' _action_path/tests/test_package/pyproject.toml
           rm ./dist/*
-          python -m build --outdir ./dist _action_path/tests/test_package
+          uv tool run --from build pyproject-build --installer=uv --outdir ./dist _action_path/tests/test_package
 
       - name: Test upload with non-main label
         uses: ./_action_path/
@@ -81,7 +78,7 @@ jobs:
           # Bump version to avoid wheel name conflicts
           sed -i 's/0.0.2/0.0.3/g' _action_path/tests/test_package/pyproject.toml
           rm ./dist/*
-          python -m build --outdir ./dist _action_path/tests/test_package
+          uv tool run --from build pyproject-build --installer=uv --outdir ./dist _action_path/tests/test_package
 
       - name: Test upload with multiple labels
         uses: ./_action_path/


### PR DESCRIPTION
* Use the `astral-sh/setup-uv` GitHub Action to setup the latest `uv`.
   - This GitHub Action can be left unpinned as it should be updated regularly.
* Use `uv tool run --from build pyproject-build` to run build as the PyPI project name is `build` but the executable it provides is named `pyproject-build`.
* Use `uv tool run twine` to run `twine`.

c.f. https://docs.astral.sh/uv/reference/cli/#uv-tool-run

## Time comparison between `python -m build`, `python -m build --installer=uv`, and `uv tool run --from build pyproject-build`:

```console
$ docker run --rm -ti python:3.12 bash
root@cfbfbb22a859:/# curl -LsSf https://astral.sh/uv/install.sh | sh
downloading uv 0.4.17 x86_64-unknown-linux-gnu
installing to /root/.cargo/bin
  uv
  uvx
everything's installed!

To add $HOME/.cargo/bin to your PATH, either restart your shell or run:

    source $HOME/.cargo/env (sh, bash, zsh)
    source $HOME/.cargo/env.fish (fish)
root@cfbfbb22a859:/# . /root/.cargo/env
root@cfbfbb22a859:/# uv venv && . .venv/bin/activate
Using CPython 3.12.6 interpreter at: /usr/local/bin/python
Creating virtual environment at: .venv
(.venv) root@cfbfbb22a859:/# git clone https://github.com/scientific-python/upload-nightly-action.git && cd upload-nightly-action
Cloning into 'upload-nightly-action'...
remote: Enumerating objects: 244, done.
remote: Counting objects: 100% (99/99), done.
remote: Compressing objects: 100% (64/64), done.
remote: Total 244 (delta 67), reused 53 (delta 35), pack-reused 145 (from 1)
Receiving objects: 100% (244/244), 107.50 KiB | 1.85 MiB/s, done.
Resolving deltas: 100% (110/110), done.
(.venv) root@cfbfbb22a859:/upload-nightly-action# uv pip install build
Resolved 3 packages in 277ms
Prepared 3 packages in 93ms
Installed 3 packages in 6ms
 + build==1.2.2
 + packaging==24.1
 + pyproject-hooks==1.2.0
(.venv) root@cfbfbb22a859:/upload-nightly-action# rm -rf dist && time python -m build --outdir ./dist ./tests/test_package
* Creating isolated environment: venv+pip...
* Installing packages in isolated environment:
  - hatchling
* Getting build dependencies for sdist...
* Building sdist...
* Building wheel from sdist
* Creating isolated environment: venv+pip...
* Installing packages in isolated environment:
  - hatchling
* Getting build dependencies for wheel...
* Building wheel...
Successfully built test_package-0.0.1.tar.gz and test_package-0.0.1-py3-none-any.whl

real	0m6.277s
user	0m5.020s
sys	0m0.444s
(.venv) root@cfbfbb22a859:/upload-nightly-action# rm -rf dist && time python -m build --installer=uv --outdir ./dist ./tests/test_package
* Creating isolated environment: venv+uv...
* Using external uv from /root/.cargo/bin/uv
* Installing packages in isolated environment:
  - hatchling
* Getting build dependencies for sdist...
* Building sdist...
* Building wheel from sdist
* Creating isolated environment: venv+uv...
* Using external uv from /root/.cargo/bin/uv
* Installing packages in isolated environment:
  - hatchling
* Getting build dependencies for wheel...
* Building wheel...
Successfully built test_package-0.0.1.tar.gz and test_package-0.0.1-py3-none-any.whl

real	0m1.012s
user	0m0.553s
sys	0m0.152s
(.venv) root@cfbfbb22a859:/upload-nightly-action# deactivate 
root@cfbfbb22a859:/upload-nightly-action# rm -rf .venv
root@cfbfbb22a859:/upload-nightly-action# rm -rf dist && time uv tool run --from build pyproject-build --installer=uv --outdir dist ./tests/test_package
* Creating isolated environment: venv+uv...
* Using external uv from /root/.cargo/bin/uv
* Installing packages in isolated environment:
  - hatchling
* Getting build dependencies for sdist...
* Building sdist...
* Building wheel from sdist
* Creating isolated environment: venv+uv...
* Using external uv from /root/.cargo/bin/uv
* Installing packages in isolated environment:
  - hatchling
* Getting build dependencies for wheel...
* Building wheel...
Successfully built test_package-0.0.1.tar.gz and test_package-0.0.1-py3-none-any.whl

real	0m0.626s
user	0m0.499s
sys	0m0.145s
root@cfbfbb22a859:/upload-nightly-action#
```