### PR TITLE
CI: Use pixi for all stages of testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,16 +96,13 @@ jobs:
       name: remove-old-wheels
 
     steps:
-      - name: Install micromamba and anaconda-client
-        uses: mamba-org/setup-micromamba@f8b8a1e23a26f60a44c853292711bacfd3eac822  # v1.9.0
+      - name: Set up pixi
+        uses: prefix-dev/setup-pixi@ba3bb36eb2066252b2363392b7739741bb777659  # v0.8.1
         with:
-          environment-name: remove-wheels
-          create-args: >-
-            python=3.12
-            anaconda-client
+          run-install: false
 
       - name: Remove test package upload
-        shell: bash -l {0}
+        shell: pixi exec --spec anaconda-client -- bash -e {0}
         run: |
             anaconda --token ${{ secrets.ANACONDA_TOKEN }} remove \
               --force \


### PR DESCRIPTION
* Use `pixi` to provide the runtime environment for removal of the `test-package` from the `scientific-python-nightly-wheels` channel.
* Use `prefix-dev/setup-pixi` to setup `pixi` with no environment created.
   - Use `run-install: false` to setup `pixi` with no install.
* Use `pixi exec --spec` to create a temporary `pixi` environment with `anaconda-client` installed for the `anaconda remove` command.

```
   $ pixi exec --help
   Run a command in a temporary environment

   Usage: pixi exec [OPTIONS] [COMMAND]...

   Arguments:
     [COMMAND]...
             The executable to run

   Options:
     -s, --spec <SPECS>
             Matchspecs of packages to install. If this is not provided, the
             package is guessed from the command
```