### PR TITLE
DOC: Clarify service is Anaconda.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ updates:
 
 To request access to the wheel channel, please open an issue on [the upload action's
 repository](https://github.com/scientific-python/upload-nightly-action). You can
-then generate a token at `https://anaconda.org/<anaconda cloud user name>/settings/access`
+then generate a token at `https://anaconda.org/<anaconda.org user name>/settings/access`
 with permissions to _Allow write access to the API site_ and _Allow uploads to Standard Python repositories_,
 and add the token as a secret to your GitHub repository.
 


### PR DESCRIPTION
* @martindurant has pointed out that Anaconda.org credentials are needed, not Anaconda Cloud credentials.