### PR TITLE
fix: remove unused permissions in actions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,9 +1,5 @@
 name: Upload Nightly
 description: A GitHub Action to upload artifacts nightly
-permissions:
-  actions: read
-  contents: read
-  metadata: read
 author: "Scientific-Python"
 version: "0.6.2"
 


### PR DESCRIPTION
Permissions key should only be at the level of workflows/jobs -- since permissions set the permissions on the PAT / `GITHUB_TOKEN` used, but actions don't have a concept of permissions. Also see the [metadata syntax](https://docs.github.com/en/actions/reference/workflows-and-actions/metadata-syntax) where there is no `permissions` key specified.