### PR TITLE
DOC: Update action commit SHA to the 0.6.3 tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ jobs:
   steps:
     ...
     - name: Upload wheel
-      uses: scientific-python/upload-nightly-action@b36e8c0c10dbcfd2e05bf95f17ef8c14fd708dbf # 0.6.2
+      uses: scientific-python/upload-nightly-action@5748273c71e2d8d3a61f3a11a16421c8954f9ecf # 0.6.3
       with:
         artifacts_path: dist
         anaconda_nightly_upload_token: ${{secrets.UPLOAD_TOKEN}}
@@ -57,7 +57,7 @@ jobs:
   steps:
     ...
     - name: Upload wheel
-      uses: scientific-python/upload-nightly-action@b36e8c0c10dbcfd2e05bf95f17ef8c14fd708dbf # 0.6.2
+      uses: scientific-python/upload-nightly-action@5748273c71e2d8d3a61f3a11a16421c8954f9ecf # 0.6.3
       with:
         artifacts_path: dist
         anaconda_nightly_upload_organization: my-alternative-organization


### PR DESCRIPTION
* For stability provide the commit SHA that corresponds to the `0.6.3` tag (5748273c71e2d8d3a61f3a11a16421c8954f9ecf) for users to pin to.