### PR TITLE
ci: Update 'Remove old wheels' workflow anaconda-client to v1.14.0

### DIFF
--- a/.github/workflows/remove-wheels.yml
+++ b/.github/workflows/remove-wheels.yml
@@ -35,8 +35,7 @@ jobs:
         with:
           environment-name: remove-wheels
           create-args: >-
-            python=3.12
-            anaconda-client=1.12.3
+            anaconda-client==1.14.0
             curl
             jq
 


### PR DESCRIPTION
While looking at Issue #155 I noticed that there were a lot of warnings filling up the CI logs

```
/home/runner/micromamba/envs/remove-wheels/lib/python3.12/site-packages/binstar_client/__init__.py:15: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  from pkg_resources import parse_version as pv
```

We can alleviate this by updating to the `v1.14.0` series, but will still have some warnings raised that are just from `anaconda-client`'s behavior.

```console
$ docker run --rm -ti ghcr.io/prefix-dev/pixi:latest 
root@3586a6ecb365:/# pixi init example && cd example && pixi add anaconda-client && pixi run anaconda remove --help
Created /example/pixi.toml
Added anaconda-client >=1.14.0,<2
/example/.pixi/envs/default/lib/python3.14/site-packages/binstar_client/commands/authorizations.py:292: PendingDeprecationWarning: FileType is deprecated. Simply open files after parsing arguments.
  token_group.add_argument('--out', default=sys.stdout, type=argparse.FileType('w'))
                                                                                                                                                                                        
 Usage: anaconda remove [OPTIONS]                                                                                                                                                       
                                                                                                                                                                                        
 Remove an object from your Anaconda repository.                                                                                                                                        
                                                                                                                                                                                        
 example::                                                                                                                                                                              
                                                                                                                                                                                        
 anaconda remove sean/meta/1.2.0/meta.tar.gz (alias for 'anaconda org remove')                                                                                                          
                                                                                                                                                                                        
╭─ Options ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ --help          Show this message and exit.                                                                                                                                          │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯

```

Note that this is a different version than what we are using in the upload workflow

https://github.com/scientific-python/upload-nightly-action/blob/f20bce66e46a975e52997ddf630f4dc8599ffcfe/pixi.toml#L12

but that isn't a problem, per se, as the workflows are fully decoupled.

* Update `anaconda-client` in the old wheels removal workflow to `v1.14.0`.
   - Drop `python` from the environment creation arguments as `python` is a dependency of `anaconda-client` and the CPython version used should not be a concern here, as this is a conda package.