### PR TITLE
DOC: Update action commit SHA to the 0.6.4 tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ jobs:
   steps:
     ...
     - name: Upload wheel
-      uses: scientific-python/upload-nightly-action@5748273c71e2d8d3a61f3a11a16421c8954f9ecf # 0.6.3
+      uses: scientific-python/upload-nightly-action@e76cfec8a4611fd02808a801b0ff5a7d7c1b2d99 # 0.6.4
       with:
         artifacts_path: dist
         anaconda_nightly_upload_token: ${{secrets.UPLOAD_TOKEN}}
@@ -57,7 +57,7 @@ jobs:
   steps:
     ...
     - name: Upload wheel
-      uses: scientific-python/upload-nightly-action@5748273c71e2d8d3a61f3a11a16421c8954f9ecf # 0.6.3
+      uses: scientific-python/upload-nightly-action@e76cfec8a4611fd02808a801b0ff5a7d7c1b2d99 # 0.6.4
       with:
         artifacts_path: dist
         anaconda_nightly_upload_organization: my-alternative-organization

--- a/action.yml
+++ b/action.yml
@@ -1,7 +1,7 @@
 name: Upload Nightly
 description: A GitHub Action to upload artifacts nightly
 author: "Scientific-Python"
-version: "0.6.3"
+version: "0.6.4"
 
 inputs:
   artifacts_path:

--- a/pixi.toml
+++ b/pixi.toml
@@ -4,7 +4,7 @@ channels = ["conda-forge"]
 description = "Environment for the scientific-python/upload-nightly-action GitHub action"
 name = "upload-nightly-action"
 platforms = ["linux-64", "linux-aarch64", "osx-64", "osx-arm64", "win-64"]
-version = "0.6.3"
+version = "0.6.4"
 requires-pixi = ">=0.67.0"
 # month window to find security issues
 exclude-newer = "30d"


### PR DESCRIPTION
* For stability provide the commit SHA that corresponds to the [`0.6.4` tag](https://github.com/scientific-python/upload-nightly-action/releases/tag/0.6.4) for users to pin to.