### PR TITLE
Add details about the consequences of not regularly uploading wheels

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,16 @@ Any versions beyond these are automatically removed as part of a daily cron job 
 Projects may have reasons to request to be added to the list exempt from this automated cleanup, however
 in that case the responsibility of cleaning-up old, unused versions fall back on the individual project.
 
+If you are a low traffic project this policy might catch you out, as the last wheel will be removed from
+this channel 30 days after it was uploaded. A low activity project might not receive updates often enough
+to produce a new wheel every 30 days. We recommend that you upload a nightly wheel on a regular cadence
+even if there are no changes.
+
+In addition cron jobs in GitHub repositories will be disabled after a certain amount of inactivity. We
+are not aware of a solution other than regular commit activity to prevent the deactivation of scheduled
+cron jobs.
+
+
 # Using nightly builds in CI
 
 To test against nightly builds, you can use the following command to install from

--- a/README.md
+++ b/README.md
@@ -78,13 +78,13 @@ Projects may have reasons to request to be added to the list exempt from this au
 in that case the responsibility of cleaning-up old, unused versions fall back on the individual project.
 
 If you are a low traffic project this policy might catch you out, as the last wheel will be removed from
-this channel 30 days after it was uploaded. A low activity project might not receive updates often enough
-to produce a new wheel every 30 days. We recommend that you upload a nightly wheel on a regular cadence
-even if there are no changes.
+this channel 30 days after it was uploaded.
+A low activity project might not receive updates often enough to produce a new wheel every 30 days.
+We recommend that you upload a nightly wheel on a regular cadence even if there are no changes.
 
-In addition cron jobs in GitHub repositories will be disabled after a certain amount of inactivity. We
-are not aware of a solution other than regular commit activity to prevent the deactivation of scheduled
-cron jobs.
+In addition cron jobs in GitHub repositories will be disabled after a certain amount of inactivity.
+We are not aware of a solution other than regular commit activity to prevent the deactivation of
+scheduled cron jobs.
 
 
 # Using nightly builds in CI


### PR DESCRIPTION
This is a follow up to https://github.com/scientific-python/upload-nightly-action/issues/171 that adds some details to the README to help low traffic projects. It highlights the problem that the nightly wheels will get cleaned up if you don't produce a wheel regularly and that this is something to consider for low traffic projects.

I also wrote that "we are not aware of a way to prevent the cron job expiry", mostly because I was not aware of a solution. There is `.github/workflows/keep-alive.yml` which I think is a solution to this problem. Should we advertise that as a potential solution?